### PR TITLE
fill visited array in detect_cycle function

### DIFF
--- a/assets/code-snippets/cycle-detection-with-spfa.cpp
+++ b/assets/code-snippets/cycle-detection-with-spfa.cpp
@@ -16,6 +16,7 @@ bool detect_cycle()
 {
     std::vector<int> vec;
     std::fill(on_stack, on_stack + n, false);
+    std::fill(visited, visited + n, false);
     for (int i = 0; i < n; ++i)
         if (!visited[i])
         {


### PR DESCRIPTION
I used this piece of code for one of my assignments to find negative cycles. But unlike here, my program was looking for negative cycles multiple times. The visited array not being filled was causing a problem in that case. When I looked at the other arrays filled in, I thought this should also be filled.